### PR TITLE
Update cicd-pages.yml

### DIFF
--- a/.github/workflows/cicd-pages.yml
+++ b/.github/workflows/cicd-pages.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ISSUE_ID: 50
+  ISSUE_ID: 55
 
 jobs:
   # Build job


### PR DESCRIPTION
This pull request includes a minor change to the `cicd-pages.yml` file under the `.github/workflows/` directory. The change updates the `ISSUE_ID` environment variable from `50` to `55` in the CI/CD workflow. This could be related to a new issue that the workflow needs to reference or work on.