### PR TITLE
Update cicd-pages.yml

### DIFF
--- a/.github/workflows/cicd-pages.yml
+++ b/.github/workflows/cicd-pages.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ISSUE_ID: 72
+  ISSUE_ID: 74
 
 jobs:
   # Build job


### PR DESCRIPTION
This pull request includes a minor change to the `ISSUE_ID` environment variable in the `.github/workflows/cicd-pages.yml` file. The `ISSUE_ID` has been updated from `72` to `74`. This change might be related to tracking or linking the workflow run to a specific issue in the project.

Esto esta relacionado al issue #74